### PR TITLE
Stylesheet alias

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ pair separated by the ampersand (``&``) character:
 xsl[]
   Relative path to a stylesheet on the server (without ``.xsl`` or ``.xslt``
   extension). This parameter can be specified multiple times.
+xa[stylesheet-key]
+  Stylesheet alias. Relative path to a stylesheet on the server (without
+  ``.xsl`` or ``.xslt``. This parameter is usefull if the same stylesheet should
+  be applied multiple times with different parameters.
 xp[stylesheet-key][param-key]
   XPath parameter with the name ``param-key`` for the stylesheet specified in
   ``stylesheet-key``. The latter need to match one of the values specified via

--- a/src/xslproxy/test/test_query_parser.py
+++ b/src/xslproxy/test/test_query_parser.py
@@ -26,10 +26,13 @@ class XslQueryParserTestCase(unittest.TestCase):
             b'&sp[first][string-param-2]=http://example.com' + \
             b'&xp[first][xpath-param]=//a/b[@c="d"]'
 
-        xsls, params = xsl.XslQueryStringParser().parse(qs)
+        xsls, paths, params = xsl.XslQueryStringParser().parse(qs)
 
         expected_xsls = ["first", "sécönd"]
         self.assertEqual(xsls, expected_xsls)
+
+        expected_paths = {"first": "first", "sécönd": "sécönd"}
+        self.assertEqual(paths, expected_paths)
 
         # These assertions are rather brittle. Regrettably XPath and XSLT
         # quoted strings do not implement equality or proper hashing. Thus we
@@ -47,3 +50,30 @@ class XslQueryParserTestCase(unittest.TestCase):
             params["first"]["xpath-param"], etree.XPath)
 
         self.assertEqual(len(params["sécönd"]), 0)
+
+    def test_query_string_with_alias(self):
+        """
+        Test query string parsing with parameters
+        """
+
+        # Generate with:
+        # urllib.parse.unquote(urllib.parse.urlencode([
+        #   ("xsl[]", "first"),
+        #   ("xsl[]", "twö"),
+        #   ("xa[twö]", "path/to/sécönd"),
+        # ])).encode('utf-8')
+
+        qs = b'xsl[]=first' + \
+            b'&xsl[]=tw\xc3\xb6' + \
+            b'&xa[tw\xc3\xb6]=path/to/s\xc3\xa9c\xc3\xb6nd'
+
+        xsls, paths, params = xsl.XslQueryStringParser().parse(qs)
+
+        expected_xsls = ["first", "twö"]
+        self.assertEqual(xsls, expected_xsls)
+
+        expected_paths = {"first": "first", "twö": "path/to/sécönd"}
+        self.assertEqual(paths, expected_paths)
+
+        expected_params = {"first": {}, "twö": {}}
+        self.assertEqual(params, expected_params)


### PR DESCRIPTION
Add a new query string parameter `xa[stylesheet-key]=stylesheet-path` in order to support transformations where the same stylesheet is used multiple times (with different parameters).